### PR TITLE
Send GB not UK as region code in the UK.

### DIFF
--- a/mcc.txt
+++ b/mcc.txt
@@ -5,7 +5,7 @@
 214	ES	Spain
 222	IT	Italy
 230	CZ	Czech Republic
-234	UK	United Kingdom
+234	GB	Great Britain
 244	FI	Finland
 250 	RU 	Russia
 260	PL	Poland


### PR DESCRIPTION
YtPlayer was sending the region id "UK" for phones in the UK, which sounds sensible but YouTube actually expects "GB" for Great Britain. This was causing the Video Categories page to fail.
