### PR TITLE
Several fixes for English and Russian translations

### DIFF
--- a/languages/ca.ts
+++ b/languages/ca.ts
@@ -77,7 +77,7 @@
         <translation>No s&apos;ha pogut carregar la pàgina d&apos;autorització OAuth</translation>
     </message>
     <message id="ytplayer-oauth-access-denied">
-        <source>YouTube OAuth access denined!</source>
+        <source>YouTube OAuth access denied!</source>
         <extracomment>Message informing the user about YouTube OAuth autorization denial</extracomment>
         <translation>S&apos;ha denegat l&apos;accés a l&apos; OAuth de YouTube</translation>
     </message>
@@ -506,7 +506,7 @@ Label informing the user there are no watched recently videos</extracomment>
         <translation>Reprèn les descàrregues automàticament</translation>
     </message>
     <message id="ytplayer-description-autoresume">
-        <source>On startup, resume all downloads which were either quened or in progress when YTPlayer was closed.</source>
+        <source>On startup, resume all downloads which were either queued or in progress when YTPlayer was closed.</source>
         <extracomment>Description of video download auto resume switch in settings</extracomment>
         <translation>En iniciar l&apos;aplicació, es reprenen totes les descàrregues que estiguessin en progrés o a la cua en el moment de tancar YTPlayer.</translation>
     </message>
@@ -833,7 +833,7 @@ Menu option allowing the user to hide search field</extracomment>
     </message>
     <message id="ytplayer-label-controls-hide-delay">
         <source>Controls hide delay</source>
-        <extracomment>Lael for slider changing video player controls hide delay</extracomment>
+        <extracomment>Label for slider changing video player controls hide delay</extracomment>
         <translation>Retard en l&apos;ocultació dels controls</translation>
     </message>
     <message id="ytplayer-label-autopause">

--- a/languages/cs_CZ.ts
+++ b/languages/cs_CZ.ts
@@ -77,7 +77,7 @@
         <translation>Nepodařilo se načíst OAuth autorizační stránku!</translation>
     </message>
     <message id="ytplayer-oauth-access-denied">
-        <source>YouTube OAuth access denined!</source>
+        <source>YouTube OAuth access denied!</source>
         <extracomment>Message informing the user about YouTube OAuth autorization denial</extracomment>
         <translation>Přístup YouTube OAuth zamítnut!</translation>
     </message>
@@ -506,7 +506,7 @@ Label informing the user there are no watched recently videos</extracomment>
         <translation>Automaticky pokračovat ve stahování</translation>
     </message>
     <message id="ytplayer-description-autoresume">
-        <source>On startup, resume all downloads which were either quened or in progress when YTPlayer was closed.</source>
+        <source>On startup, resume all downloads which were either queued or in progress when YTPlayer was closed.</source>
         <extracomment>Description of video download auto resume switch in settings</extracomment>
         <translation>Po startu pokračovat ve stahování všech videí, které byly zařazeny do fronty, nebo probíhaly, než byl YTPlayer zavřen.</translation>
     </message>
@@ -833,7 +833,7 @@ Menu option allowing the user to hide search field</extracomment>
     </message>
     <message id="ytplayer-label-controls-hide-delay">
         <source>Controls hide delay</source>
-        <extracomment>Lael for slider changing video player controls hide delay</extracomment>
+        <extracomment>Label for slider changing video player controls hide delay</extracomment>
         <translation>Zpoždění skrytí ovládacích prvků</translation>
     </message>
     <message id="ytplayer-label-autopause">

--- a/languages/de.ts
+++ b/languages/de.ts
@@ -77,7 +77,7 @@
         <translation>Laden der OAuth-Authorisierungsseite fehlgeschlagen!</translation>
     </message>
     <message id="ytplayer-oauth-access-denied">
-        <source>YouTube OAuth access denined!</source>
+        <source>YouTube OAuth access denied!</source>
         <extracomment>Message informing the user about YouTube OAuth autorization denial</extracomment>
         <translation>YouTube OAuth-Zugriff verweigert!</translation>
     </message>
@@ -506,7 +506,7 @@ Label informing the user there are no watched recently videos</extracomment>
         <translation>Setze Downloads automatisch fort</translation>
     </message>
     <message id="ytplayer-description-autoresume">
-        <source>On startup, resume all downloads which were either quened or in progress when YTPlayer was closed.</source>
+        <source>On startup, resume all downloads which were either queued or in progress when YTPlayer was closed.</source>
         <extracomment>Description of video download auto resume switch in settings</extracomment>
         <translation>Setze beim Starten alle Downloads fort, die entweder eingereiht waren oder heruntergeladen wurden, als YTPlayer geschlossen wurde</translation>
     </message>
@@ -833,7 +833,7 @@ Menu option allowing the user to hide search field</extracomment>
     </message>
     <message id="ytplayer-label-controls-hide-delay">
         <source>Controls hide delay</source>
-        <extracomment>Lael for slider changing video player controls hide delay</extracomment>
+        <extracomment>Label for slider changing video player controls hide delay</extracomment>
         <translation>Verzögerung beim Steueremelente verstecken</translation>
     </message>
     <message id="ytplayer-label-autopause">

--- a/languages/en_GB.ts
+++ b/languages/en_GB.ts
@@ -46,7 +46,7 @@
     <message id="ytplayer-label-region-code">
         <source>Region code: %1</source>
         <extracomment>Region code field value</extracomment>
-        <translation>Region Code: %1</translation>
+        <translation>Region code: %1</translation>
     </message>
     <message id="ytplayer-label-publish-date">
         <source>Published on</source>
@@ -79,7 +79,7 @@
         <translation>Failed to load OAuth authorization page!</translation>
     </message>
     <message id="ytplayer-oauth-access-denied">
-        <source>YouTube OAuth access denined!</source>
+        <source>YouTube OAuth access denied!</source>
         <extracomment>Message informing the user about YouTube OAuth autorization denial</extracomment>
         <translation>YouTube OAuth access denied!</translation>
     </message>
@@ -508,7 +508,7 @@ Label informing the user there are no watched recently videos</extracomment>
         <translation>Automatically resume downloads</translation>
     </message>
     <message id="ytplayer-description-autoresume">
-        <source>On startup, resume all downloads which were either quened or in progress when YTPlayer was closed.</source>
+        <source>On startup, resume all downloads which were either queued or in progress when YTPlayer was closed.</source>
         <extracomment>Description of video download auto resume switch in settings</extracomment>
         <translation>On startup, resume all downloads which were either queued or in progress when YTPlayer was closed.</translation>
     </message>
@@ -618,7 +618,7 @@ Remorse popup message telling the user video download will be removed</extracomm
     <message id="ytplayer-description-account-integration">
         <source>Allow YTPlayer to manage YouTube user account.</source>
         <extracomment>Description of switch activating/deactivating YouTube account integration</extracomment>
-        <translation>Allow YTPlayer to manager YouTube user account.</translation>
+        <translation>Allow YTPlayer to manage YouTube user account.</translation>
     </message>
     <message id="ytplayer-msg-channel-subscribed">
         <source>Channel subscribed</source>
@@ -628,7 +628,7 @@ Remorse popup message telling the user video download will be removed</extracomm
     <message id="ytplayer-msg-unsubscribing-channel">
         <source>Unsubscribing channel</source>
         <extracomment>Remorse popup message telling the user channel is about to be unsubscribed</extracomment>
-        <translation>Unsiscribing channel</translation>
+        <translation>Unsubscribing channel</translation>
     </message>
     <message id="ytplayer-msg-channel-unsubscribed">
         <source>Channel unsubscribed</source>
@@ -835,7 +835,7 @@ Menu option allowing the user to hide search field</extracomment>
     </message>
     <message id="ytplayer-label-controls-hide-delay">
         <source>Controls hide delay</source>
-        <extracomment>Lael for slider changing video player controls hide delay</extracomment>
+        <extracomment>Label for slider changing video player controls hide delay</extracomment>
         <translation>Controls hide delay</translation>
     </message>
     <message id="ytplayer-label-autopause">
@@ -923,3 +923,4 @@ Menu option allowing the user to hide search field</extracomment>
     </message>
 </context>
 </TS>
+:q

--- a/languages/es.ts
+++ b/languages/es.ts
@@ -77,7 +77,7 @@
         <translation>¡No se ha podido cargar la página de autorización OAuth!</translation>
     </message>
     <message id="ytplayer-oauth-access-denied">
-        <source>YouTube OAuth access denined!</source>
+        <source>YouTube OAuth access denied!</source>
         <extracomment>Message informing the user about YouTube OAuth autorization denial</extracomment>
         <translation>¡Acceso denegado al OAuth de YouTube!</translation>
     </message>
@@ -506,7 +506,7 @@ Label informing the user there are no watched recently videos</extracomment>
         <translation>Reanudar las descargas automáticamente</translation>
     </message>
     <message id="ytplayer-description-autoresume">
-        <source>On startup, resume all downloads which were either quened or in progress when YTPlayer was closed.</source>
+        <source>On startup, resume all downloads which were either queued or in progress when YTPlayer was closed.</source>
         <extracomment>Description of video download auto resume switch in settings</extracomment>
         <translation>Al iniciar, se reanudan todas las descargas que estaban en cola o en proceso cuando se cerró YTPlayer.</translation>
     </message>
@@ -833,7 +833,7 @@ Menu option allowing the user to hide search field</extracomment>
     </message>
     <message id="ytplayer-label-controls-hide-delay">
         <source>Controls hide delay</source>
-        <extracomment>Lael for slider changing video player controls hide delay</extracomment>
+        <extracomment>Label for slider changing video player controls hide delay</extracomment>
         <translation>Retraso en la ocultación de controles</translation>
     </message>
     <message id="ytplayer-label-autopause">

--- a/languages/fr_FR.ts
+++ b/languages/fr_FR.ts
@@ -77,7 +77,7 @@
         <translation>Le chargement de la page d&apos;autorisation OAuth à échoué!</translation>
     </message>
     <message id="ytplayer-oauth-access-denied">
-        <source>YouTube OAuth access denined!</source>
+        <source>YouTube OAuth access denied!</source>
         <extracomment>Message informing the user about YouTube OAuth autorization denial</extracomment>
         <translation>L&apos;accès à l&apos;OAuth YouTube a échoué!</translation>
     </message>
@@ -506,7 +506,7 @@ Label informing the user there are no watched recently videos</extracomment>
         <translation>Reprendre automatiquement les téléchargements</translation>
     </message>
     <message id="ytplayer-description-autoresume">
-        <source>On startup, resume all downloads which were either quened or in progress when YTPlayer was closed.</source>
+        <source>On startup, resume all downloads which were either queued or in progress when YTPlayer was closed.</source>
         <extracomment>Description of video download auto resume switch in settings</extracomment>
         <translation>Au démarrage, reprendre tous les téléchargements qui étaient en attente ou en cours lors de la fermeture de YTPlayer.</translation>
     </message>
@@ -833,7 +833,7 @@ Menu option allowing the user to hide search field</extracomment>
     </message>
     <message id="ytplayer-label-controls-hide-delay">
         <source>Controls hide delay</source>
-        <extracomment>Lael for slider changing video player controls hide delay</extracomment>
+        <extracomment>Label for slider changing video player controls hide delay</extracomment>
         <translation>Délai de masquage des contrôles</translation>
     </message>
     <message id="ytplayer-label-autopause">

--- a/languages/it_IT.ts
+++ b/languages/it_IT.ts
@@ -77,7 +77,7 @@
         <translation>Impossibile caricare la pagina di autorizzazione OAuth!</translation>
     </message>
     <message id="ytplayer-oauth-access-denied">
-        <source>YouTube OAuth access denined!</source>
+        <source>YouTube OAuth access denied!</source>
         <extracomment>Message informing the user about YouTube OAuth autorization denial</extracomment>
         <translation>Accesso OAuth di YouTube negato!</translation>
     </message>
@@ -506,7 +506,7 @@ Label informing the user there are no watched recently videos</extracomment>
         <translation>Riprendi automaticamente i download</translation>
     </message>
     <message id="ytplayer-description-autoresume">
-        <source>On startup, resume all downloads which were either quened or in progress when YTPlayer was closed.</source>
+        <source>On startup, resume all downloads which were either queued or in progress when YTPlayer was closed.</source>
         <extracomment>Description of video download auto resume switch in settings</extracomment>
         <translation>All&apos;avvio, riprendere tutti i download che erano in coda o in corso quando YTPlayer è stato chiuso.</translation>
     </message>
@@ -833,7 +833,7 @@ Menu option allowing the user to hide search field</extracomment>
     </message>
     <message id="ytplayer-label-controls-hide-delay">
         <source>Controls hide delay</source>
-        <extracomment>Lael for slider changing video player controls hide delay</extracomment>
+        <extracomment>Label for slider changing video player controls hide delay</extracomment>
         <translation>Controlli nascondi ritardo</translation>
     </message>
     <message id="ytplayer-label-autopause">

--- a/languages/nl_NL.ts
+++ b/languages/nl_NL.ts
@@ -99,7 +99,7 @@
         <translation>Mislukt om OAuth-authorisatiepagina te laden!</translation>
     </message>
     <message id="ytplayer-oauth-access-denied">
-        <source>YouTube OAuth access denined!</source>
+        <source>YouTube OAuth access denied!</source>
         <extracomment>Message informing the user about YouTube OAuth autorization denial</extracomment>
         <translation>YouTube OAuth-toegang geweigerd!</translation>
     </message>
@@ -523,7 +523,7 @@ Label informing the user there are no watched recently videos</extracomment>
         <translation>Downloads automatisch hervatten</translation>
     </message>
     <message id="ytplayer-description-autoresume">
-        <source>On startup, resume all downloads which were either quened or in progress when YTPlayer was closed.</source>
+        <source>On startup, resume all downloads which were either queued or in progress when YTPlayer was closed.</source>
         <extracomment>Description of video download auto resume switch in settings</extracomment>
         <translation>Alle downloads in de wachtrij of die bezig waren met downloaden toen YTPlayer werd gesloten hervatten bij het opstarten.</translation>
     </message>
@@ -816,7 +816,7 @@ Label informing the user there are no watched recently videos</extracomment>
     </message>
     <message id="ytplayer-label-controls-hide-delay">
         <source>Controls hide delay</source>
-        <extracomment>Lael for slider changing video player controls hide delay</extracomment>
+        <extracomment>Label for slider changing video player controls hide delay</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="ytplayer-label-autoload">

--- a/languages/pl_PL.ts
+++ b/languages/pl_PL.ts
@@ -77,7 +77,7 @@
         <translation>Nie udało się załadować strony autoryzacji OAuth!</translation>
     </message>
     <message id="ytplayer-oauth-access-denied">
-        <source>YouTube OAuth access denined!</source>
+        <source>YouTube OAuth access denied!</source>
         <extracomment>Message informing the user about YouTube OAuth autorization denial</extracomment>
         <translation>YouTube OAuth odmowa dostępu!</translation>
     </message>
@@ -506,7 +506,7 @@ Label informing the user there are no watched recently videos</extracomment>
         <translation>Automatycznie wznawiaj pobieranie</translation>
     </message>
     <message id="ytplayer-description-autoresume">
-        <source>On startup, resume all downloads which were either quened or in progress when YTPlayer was closed.</source>
+        <source>On startup, resume all downloads which were either queued or in progress when YTPlayer was closed.</source>
         <extracomment>Description of video download auto resume switch in settings</extracomment>
         <translation>Podczas statu, wznów wszystkie pobierania, które były pobierane lub zakolejkowane podczas zanmykanie YTPlayera.</translation>
     </message>
@@ -833,7 +833,7 @@ Menu option allowing the user to hide search field</extracomment>
     </message>
     <message id="ytplayer-label-controls-hide-delay">
         <source>Controls hide delay</source>
-        <extracomment>Lael for slider changing video player controls hide delay</extracomment>
+        <extracomment>Label for slider changing video player controls hide delay</extracomment>
         <translation>Opóźnienie ukrycia kontrolek</translation>
     </message>
     <message id="ytplayer-label-autopause">

--- a/languages/ru_RU.ts
+++ b/languages/ru_RU.ts
@@ -78,7 +78,7 @@
         <translation>Не удалось загрузить страницу авторизации OAuth!</translation>
     </message>
     <message id="ytplayer-oauth-access-denied">
-        <source>YouTube OAuth access denined!</source>
+        <source>YouTube OAuth access denied!</source>
         <extracomment>Message informing the user about YouTube OAuth autorization denial</extracomment>
         <translation>Доступ запрещен!</translation>
     </message>
@@ -508,7 +508,7 @@ Label informing the user there are no watched recently videos</extracomment>
         <translation>Автоматически продолжать загрузки</translation>
     </message>
     <message id="ytplayer-description-autoresume">
-        <source>On startup, resume all downloads which were either quened or in progress when YTPlayer was closed.</source>
+        <source>On startup, resume all downloads which were either queued or in progress when YTPlayer was closed.</source>
         <extracomment>Description of video download auto resume switch in settings</extracomment>
         <translation>Автоматически продолжать все незавершенные загрузки или загрузки в очереди при старте.</translation>
     </message>
@@ -835,7 +835,7 @@ Menu option allowing the user to hide search field</extracomment>
     </message>
     <message id="ytplayer-label-controls-hide-delay">
         <source>Controls hide delay</source>
-        <extracomment>Lael for slider changing video player controls hide delay</extracomment>
+        <extracomment>Label for slider changing video player controls hide delay</extracomment>
         <translation>Показывать меню</translation>
     </message>
     <message id="ytplayer-label-autopause">

--- a/languages/ru_RU.ts
+++ b/languages/ru_RU.ts
@@ -199,8 +199,7 @@ Button for showing license viewer page</extracomment>
     <message id="ytplayer-label-application-license">
         <source>YTPlayer is licensed under 3-clause BSD License</source>
         <extracomment>Label displaying YTPlayer licensing information</extracomment>
-        <translation>YTPlayer распространяется под лицензией
-3-clause BSD</translation>
+        <translation>YTPlayer распространяется на условиях 3-clause BSD</translation>
     </message>
     <message id="ytplayer-action-third-party-software">
         <source>Third party software</source>
@@ -613,12 +612,12 @@ Remorse popup message telling the user video download will be removed</extracomm
     <message id="ytplayer-label-account-integration">
         <source>YouTube account integration</source>
         <extracomment>Label of switch activating/deactivating YouTube account integration</extracomment>
-        <translation>Интеграция с аккаунтом YouTube</translation>
+        <translation>Использовать учётную запись YouTube</translation>
     </message>
     <message id="ytplayer-description-account-integration">
         <source>Allow YTPlayer to manage YouTube user account.</source>
         <extracomment>Description of switch activating/deactivating YouTube account integration</extracomment>
-        <translation>Разрешить YTPlayer управлять аккаунтом YouTube.</translation>
+        <translation>Разрешить YTPlayer управлять учётной записью YouTube.</translation>
     </message>
     <message id="ytplayer-msg-channel-subscribed">
         <source>Channel subscribed</source>
@@ -714,22 +713,22 @@ Remorse popup message telling the user video download will be removed</extracomm
     <message id="ytplayer-action-save-log">
         <source>Save log</source>
         <extracomment>Menu action allowing the user to save application log</extracomment>
-        <translation>Сохранить лог</translation>
+        <translation>Сохранить журнал</translation>
     </message>
     <message id="ytplayer-msg-saving-log">
         <source>Saving log</source>
         <extracomment>Remorse popup message telling the user log file will be saved</extracomment>
-        <translation>Сохранение лога</translation>
+        <translation>Сохранение журнала</translation>
     </message>
     <message id="ytplayer-msg-log-saved">
         <source>Log saved</source>
         <extracomment>Body of notification informing the user application log was saved</extracomment>
-        <translation>Лог сохранен</translation>
+        <translation>Журнал сохранен</translation>
     </message>
     <message id="ytplayer-action-view-logs">
         <source>View logs</source>
         <extracomment>Label for menu option showing application log viewer</extracomment>
-        <translation>Просмотр логов</translation>
+        <translation>Просмотр журнала</translation>
     </message>
     <message id="ytplayer-title-language-settings">
         <source>Language settings</source>
@@ -791,7 +790,7 @@ Remorse popup message telling the user video download will be removed</extracomm
         <extracomment>Menu option allowing the user to hide search field
 ----------
 Menu option allowing the user to hide search field</extracomment>
-        <translation>Спрятать строку поиска</translation>
+        <translation>Убрать строку поиска</translation>
     </message>
     <message id="ytplayer-msg-removing-favorite">
         <source>Removing favorite</source>

--- a/languages/sv.ts
+++ b/languages/sv.ts
@@ -77,7 +77,7 @@
         <translation>Kunde inte läsa in inloggningssidan!</translation>
     </message>
     <message id="ytplayer-oauth-access-denied">
-        <source>YouTube OAuth access denined!</source>
+        <source>YouTube OAuth access denied!</source>
         <extracomment>Message informing the user about YouTube OAuth autorization denial</extracomment>
         <translation>YouTube-åtkomst nekades!</translation>
     </message>
@@ -506,7 +506,7 @@ Label informing the user there are no watched recently videos</extracomment>
         <translation>Återuppta nedladdningar automatiskt</translation>
     </message>
     <message id="ytplayer-description-autoresume">
-        <source>On startup, resume all downloads which were either quened or in progress when YTPlayer was closed.</source>
+        <source>On startup, resume all downloads which were either queued or in progress when YTPlayer was closed.</source>
         <extracomment>Description of video download auto resume switch in settings</extracomment>
         <translation>Vid uppstart återupptas alla nedladdningar som var antingen köade eller under nedladdning när YTPlayer stängdes.</translation>
     </message>
@@ -833,7 +833,7 @@ Menu option allowing the user to hide search field</extracomment>
     </message>
     <message id="ytplayer-label-controls-hide-delay">
         <source>Controls hide delay</source>
-        <extracomment>Lael for slider changing video player controls hide delay</extracomment>
+        <extracomment>Label for slider changing video player controls hide delay</extracomment>
         <translation>Kontrollfördröjning</translation>
     </message>
     <message id="ytplayer-label-autopause">

--- a/qml/pages/DownloadSettings.qml
+++ b/qml/pages/DownloadSettings.qml
@@ -43,7 +43,7 @@ Page {
                 //% "Automatically resume downloads"
                 text: qsTrId("ytplayer-label-autoresume")
                 //: Description of video download auto resume switch in settings
-                //% "On startup, resume all downloads which were either quened or "
+                //% "On startup, resume all downloads which were either queued or "
                 //% "in progress when YTPlayer was closed."
                 description: qsTrId("ytplayer-description-autoresume")
                 checked: YTPrefs.getBool("Download/ResumeOnStartup")

--- a/qml/pages/PlayerSettings.qml
+++ b/qml/pages/PlayerSettings.qml
@@ -41,7 +41,7 @@ Page {
             }
 
             Slider {
-                //: Lael for slider changing video player controls hide delay
+                //: Label for slider changing video player controls hide delay
                 //% "Controls hide delay"
                 label: qsTrId("ytplayer-label-controls-hide-delay")
                 width: parent.width

--- a/qml/pages/YTOAuth2.qml
+++ b/qml/pages/YTOAuth2.qml
@@ -130,7 +130,7 @@ Page {
             } else if (title.indexOf('Denied error') !== -1) {
                 Log.debug("Youtube OAuth access denied!")
                 //: Message informing the user about YouTube OAuth autorization denial
-                //% "YouTube OAuth access denined!"
+                //% "YouTube OAuth access denied!"
                 failureNotification.previewBody = qsTrId("ytplayer-oauth-access-denied")
                 failureNotification.publish()
                 pageStack.navigateBack(PageStackAction.Animated)


### PR DESCRIPTION
Mostly typos for English, mostly "Russification" for Russian (prefer more common words to jargon).

Also, fix typos in string identifiers (sources).
